### PR TITLE
enable default sound for push notifications

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -54,6 +54,7 @@ async fn notify_device(mut req: tide::Request<State>) -> tide::Result<tide::Resp
         .set_title_loc_key("new_messages") // Localization key for the title.
         .set_body("You have new messages")
         .set_loc_key("new_messages_body") // Localization key for the body.
+        .set_sound("default")
         .set_mutable_content()
         .build(
             device_token,


### PR DESCRIPTION
_nb: i just guessed the syntax as i could not find documentation for DefaultNotificationBuilder, and also could not test the PR ;)_

this PR sets the sound of the notification to "default".

sound or vibration can be disabled or changed by the user, but without specifying a sound in the APS json,
there will be never a sound and the user won't be able to enable one.

expected APS json syntax is described at
https://developer.apple.com/documentation/usernotifications/generating-a-remote-notification

