### PR TITLE
set `apns-push-type: alert` http-header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,8 +5,7 @@ version = 3
 [[package]]
 name = "a2"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da60b150c4846f18f007bbdf912cefe83aaa88fe6725b8bfc3529e5fd3caa895"
+source = "git+https://github.com/gferon/a2/?branch=apns-push-type#a8d689273bd456a54a9cab8043e1caa308ac16ca"
 dependencies = [
  "base64 0.20.0",
  "erased-serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-a2 = "0.8"
+a2 = { git = "https://github.com/gferon/a2/", branch = "apns-push-type" }
 anyhow = "1.0.32"
 async-std = { version = "1.9", features = ["tokio1", "attributes", "unstable"] }
 femme = "2.1.0"

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,6 +1,6 @@
 use a2::{
     DefaultNotificationBuilder, Error::ResponseError, NotificationBuilder, NotificationOptions,
-    Priority,
+    Priority, PushType,
 };
 use anyhow::Result;
 use log::*;
@@ -63,6 +63,7 @@ async fn notify_device(mut req: tide::Request<State>) -> tide::Result<tide::Resp
                 // <https://developer.apple.com/documentation/usernotifications/sending-notification-requests-to-apns>
                 apns_priority: Some(Priority::High),
                 apns_topic: req.state().topic(),
+                apns_push_type: Some(PushType::Alert),
                 ..Default::default()
             },
         );


### PR DESCRIPTION
set `apns-push-type: alert` http-header

the header is required to make use of the not-show-notifications entitlement, see https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_usernotifications_filtering :
 
> To silence a remote notification,
> you must set the apns-push-type header field to alert
> when you send the notification to the APNS server.
> Otherwise, the system always displays the notification banner to the user.

there is lots of things to do to make the "notification filter entitlement" (https://github.com/deltachat/deltachat-ios/pull/2124) work, this seems to be one puzzle piece. it is needed at least to exclude this as a source of errors, also seems mandatory.

ng: i could not test the PR and i have no idea wrt deployment and if it is a good idea to use the PRs this way, l leave this part to the sysadmins :)